### PR TITLE
Two inference modes (Live / Aim & Capture) + NCNN backend badge

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -101,11 +101,12 @@ async def health():
 async def predict(
     file: UploadFile,
     conf: float = Form(default=0.4),
+    full: bool = Form(default=False),   # True = full-res (Aim & Capture); else 50% downscale
 ):
     image_bytes = await file.read()
 
     detections, total_count, annotated_img_bytes = inference.run_inference_with_count(
-        image_bytes, conf=conf
+        image_bytes, conf=conf, scale_factor=(1.0 if full else 0.5)
     )
 
     if total_count != 9:
@@ -248,10 +249,18 @@ def _platform_info() -> dict:
         has_picamera2 = True
     except Exception:
         has_picamera2 = False
+    is_raspi = is_linux and has_picamera2
     return {
-        "is_raspi": is_linux and has_picamera2,
+        "is_raspi": is_raspi,
         "has_picamera2": has_picamera2,
         "default_camera_mode": "server" if has_picamera2 else "client",
+        # Which inference backend actually loaded ("ncnn" = fast CPU path, "pytorch" =
+        # slower fallback). Shown as a badge in Settings. See docs/STREAM_PERFORMANCE.md.
+        "model_backend": inference.MODEL_BACKEND,
+        # Default inference mode: the Pi (NCNN + multiple cores) can do live video;
+        # elsewhere (e.g. the 1-vCPU VPS) default to "snapshot" (smooth preview + one
+        # accurate capture). User can override in Settings; the choice is persisted.
+        "default_inference_mode": "live" if is_raspi else "snapshot",
     }
 
 
@@ -282,7 +291,8 @@ async def put_settings_endpoint(request: Request):
     Upsert UI settings. Accepts a JSON body of {key: value} pairs.
     Only known setting keys are persisted; unknown keys are silently ignored.
     """
-    ALLOWED_KEYS = {"cameraMode", "fps", "resolution", "confidence", "flipHorizontal"}
+    ALLOWED_KEYS = {"cameraMode", "fps", "resolution", "confidence", "flipHorizontal",
+                    "inferenceMode"}
     try:
         body = await request.json()
     except Exception:
@@ -355,6 +365,10 @@ async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     camera = Camera()
     session_conf: float = 0.4
+    # Server-camera inference toggle. True (default) = "live" mode: run inference on every
+    # frame. False = "snapshot/preview" mode: stream raw camera frames (smooth, no
+    # inference) and only run a full-res reading when a "capture_now" arrives.
+    server_infer: bool = True
     last_infer: float = 0.0  # monotonic timestamp of the last processed frame
     # Per-session inference-rate cap (see docs/STREAM_PERFORMANCE.md, Option B).
     # Starts from the env default; the client's "Max FPS" slider overrides it live via
@@ -403,6 +417,9 @@ async def websocket_endpoint(websocket: WebSocket):
                     msg = json.loads(data["text"])
 
                     if msg.get("action") == "start_server_stream":
+                        # "preview": true → snapshot mode (raw frames, no per-frame
+                        # inference). Default false → live inference.
+                        server_infer = not bool(msg.get("preview", False))
                         if not camera.is_running:
                             resolution = msg.get("resolution", "640x480")
                             source = msg.get("source", 0)
@@ -440,6 +457,30 @@ async def websocket_endpoint(websocket: WebSocket):
                         except (TypeError, ValueError):
                             logger.warning("Invalid fps value: %s", msg.get("value"))
 
+                    elif msg.get("action") == "capture_now":
+                        # Aim & Capture (server camera): one FULL-RESOLUTION reading from
+                        # the current camera frame. Runs regardless of the FPS throttle.
+                        if camera.is_running:
+                            frame = camera.get_frame()
+                            if frame is not None:
+                                ok, enc = cv2.imencode(".jpg", frame)
+                                if ok:
+                                    dets, cnt, ann = inference.run_inference_with_count(
+                                        enc.tobytes(), conf=session_conf, scale_factor=1.0
+                                    )
+                                    await websocket.send_json({
+                                        "mode": "server",
+                                        "capture": True,
+                                        "detections": dets,
+                                        "total_tubes": cnt,
+                                        **_compute_mpn(dets, cnt),
+                                        "image": base64.b64encode(ann).decode("utf-8"),
+                                    })
+                        else:
+                            await websocket.send_json(
+                                {"mode": "server", "error": "Camera not running"}
+                            )
+
             except asyncio.TimeoutError:
                 # ---------------------------------------------------------
                 # SERVER MODE
@@ -461,6 +502,17 @@ async def websocket_endpoint(websocket: WebSocket):
 
                 success, encoded_img = cv2.imencode(".jpg", frame)
                 if not success:
+                    continue
+
+                # Snapshot/preview mode: stream the raw camera frame (no inference) so
+                # the operator can aim smoothly. The reading runs on "capture_now".
+                if not server_infer:
+                    await websocket.send_json({
+                        "mode": "server",
+                        "preview": True,
+                        "image": base64.b64encode(encoded_img.tobytes()).decode("utf-8"),
+                    })
+                    await asyncio.sleep(0.03)
                     continue
 
                 image_bytes = encoded_img.tobytes()

--- a/app/inference.py
+++ b/app/inference.py
@@ -27,16 +27,24 @@ _NCNN_DIR = _MODELS_DIR / "best_ncnn_model"
 _PT_PATH = _MODELS_DIR / "vialvision_yolo26.pt"
 
 
+# Which backend actually loaded — exposed to the UI (Settings shows an NCNN/PyTorch
+# badge) so it's obvious on each deployment whether the fast path is in use.
+MODEL_BACKEND = "unknown"
+
+
 def _resolve_model_path() -> str:
+    global MODEL_BACKEND
     if _NCNN_DIR.exists():
         try:
             import ncnn  # noqa: F401 — is the NCNN runtime available?
             logger.info("Using NCNN model at %s", _NCNN_DIR)
+            MODEL_BACKEND = "ncnn"
             return str(_NCNN_DIR)
         except Exception:
             logger.info("ncnn runtime not installed; falling back to PyTorch weights.")
     if _PT_PATH.exists():
         logger.info("Using PyTorch model at %s", _PT_PATH)
+        MODEL_BACKEND = "pytorch"
         return str(_PT_PATH)
     raise FileNotFoundError(
         f"No model found in {_MODELS_DIR}. Copy the trained model there "
@@ -159,14 +167,18 @@ def tubes_to_xyz(tubes):
 # Public inference entry point
 # ---------------------------------------------------------------------------
 
-def run_inference_with_count(image_bytes: bytes, conf: float = 0.4):
+def run_inference_with_count(image_bytes: bytes, conf: float = 0.4,
+                             scale_factor: float = 0.5):
     """
     Full inference pipeline: load image -> downscale -> YOLO -> deduplicate ->
     annotate -> return results.
 
     Args:
-        image_bytes: Raw image file contents (any format PIL can open).
-        conf:        YOLO confidence threshold (0.0-1.0). Defaults to 0.4.
+        image_bytes:  Raw image file contents (any format PIL can open).
+        conf:         YOLO confidence threshold (0.0-1.0). Defaults to 0.4.
+        scale_factor: Pre-inference resize factor. 0.5 (default) is the fast live-stream
+                      path; pass 1.0 for a full-resolution "Aim & Capture" reading (most
+                      accurate). See docs/STREAM_PERFORMANCE.md (Two inference modes).
 
     Returns:
         detections (list[dict]): Each dict has 'label', 'confidence', 'bbox'.
@@ -174,13 +186,14 @@ def run_inference_with_count(image_bytes: bytes, conf: float = 0.4):
         annotated_image (bytes): JPEG image with bounding boxes drawn.
     """
     conf = max(0.05, min(0.95, conf))
+    scale_factor = max(0.1, min(1.0, scale_factor))
 
-    # ---- Load & downscale image (50%) ----
+    # ---- Load & (optionally) downscale image ----
     image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
-    scale_factor = 0.5
-    new_w = int(image.width * scale_factor)
-    new_h = int(image.height * scale_factor)
-    image = image.resize((new_w, new_h), Image.LANCZOS)
+    if scale_factor < 1.0:
+        new_w = int(image.width * scale_factor)
+        new_h = int(image.height * scale_factor)
+        image = image.resize((new_w, new_h), Image.LANCZOS)
 
     # ---- Run YOLO ----
     results = model(image, conf=conf, iou=0.6, agnostic_nms=True)

--- a/docs/ACCURACY_IMPROVEMENT.md
+++ b/docs/ACCURACY_IMPROVEMENT.md
@@ -257,3 +257,33 @@ See [TESTING.md](TESTING.md) for where an automated harness would live.
 
 _Benchmark figures above are Ultralytics' official COCO / Raspberry Pi 5 numbers and
 are indicative; validate on our own eval set and hardware before deciding._
+
+---
+
+## Real-world domain shift (deployed model fails on uncontrolled photos) — 2026-08-08
+
+**Symptom:** after deployment, the model failed on a casual phone photo (dim room, blue
+keyboard-RGB colour cast, unfamiliar white stand) — it found only 1–3 *clustered* boxes,
+not 9, and mislabelled colours.
+
+**Root cause: domain shift — not a saturation-only issue.** The model was trained on a
+narrow, specific rig (bright, even light; foam background). Changing lighting + white
+balance + background + camera all at once makes **both localisation and classification**
+break. The model generalises only to conditions close to its training data.
+
+**Two deployment targets, two answers:**
+- **Controlled appliance (Pi + fixed jig) — primary, reliable:** control the environment
+  with a **light box / diffuser** (kills colour casts), a fixed background + distance, and
+  **retrain on data captured through that exact rig** so *training conditions == deployment
+  conditions*. (**Track 3** — environment/dataset owned by the user.)
+- **Wild phones (web/VPS) — much harder:** needs a **large, diverse dataset** (many
+  lightings, backgrounds, phones — including messy ones) to generalise. A big data effort;
+  set expectations that it works best in decent light until that exists.
+
+**Tension to navigate:** we deliberately avoided hue/saturation augmentation to keep
+yellow-vs-purple crisp — which is exactly what makes the model brittle to colour casts. For
+the wild case, carefully reintroduce some white-balance/colour robustness (or normalise WB
+in preprocessing) **without** destroying the colour discrimination.
+
+> Note: **NCNN vs PyTorch is unrelated** to this — the backend only affects *speed*, not
+> detection quality. See [STREAM_PERFORMANCE.md](STREAM_PERFORMANCE.md).

--- a/docs/STREAM_PERFORMANCE.md
+++ b/docs/STREAM_PERFORMANCE.md
@@ -153,3 +153,34 @@ and porting the decode/dedup logic.
    streaming is required, either move to a **2 vCPU** droplet or pursue **C**.
 3. **C** is the proper answer for scale, but it's a genuine rewrite — schedule it
    only if per-device/real-time streaming becomes a hard requirement.
+
+---
+
+## Two inference modes (Live vs Aim & Capture) — implemented 2026-08-08
+
+Live per-frame inference is CPU-bound and never smooth on the VPS (1 vCPU). Rather than
+fight that, **Settings → Inference Mode** offers two modes (persisted per device):
+
+| Mode | Preview | Reading | Best for |
+|---|---|---|---|
+| **Live** | annotated every frame | continuous | Pi (NCNN + multiple cores) |
+| **Aim & Capture** | raw camera, **no inference** (smooth) | one **full-resolution** reading on the "Capture & Analyze" button | VPS, and any accurate read |
+
+Aim & Capture wins twice: the preview is smooth (zero inference cost), and the reading is
+the **most accurate** (full resolution — the live path downscales 50 %).
+
+**Implementation:**
+- Setting `inferenceMode` = `live` | `snapshot`, persisted. Default `live` on the Pi,
+  `snapshot` elsewhere (`api._platform_info()` → `default_inference_mode`).
+- **Client camera:** preview is the local `<video>` (no server round-trip); Capture →
+  `POST /predict` with `full=true`.
+- **Server (Pi) camera:** `start_server_stream {preview:true}` streams raw frames (no
+  inference); `capture_now` runs one full-res reading. See `app/api.py`.
+- Full-res path: `run_inference_with_count(scale_factor=1.0)`; the live path stays at 0.5.
+
+## NCNN status indicator
+
+Settings shows an **Inference Backend** badge — **"NCNN (fast)"** or **"PyTorch (slower)"**
+— from `_platform_info().model_backend` (set in `inference._resolve_model_path()`). If a
+deployment shows **PyTorch**, the `ncnn` runtime isn't installed there and it fell back to
+the slow path; fix by ensuring `ncnn` is in the environment.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1749,3 +1749,15 @@ tbody tr:hover td { background: var(--bg-hover); }
   color: var(--text-muted);
   text-align: center;
 }
+/* Inference backend badge (Settings) */
+.backend-badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 12px;
+    font-size: 0.85em;
+    font-weight: 600;
+    background: #2a2a2a;
+    color: #e0e0e0;
+}
+.backend-badge.ok   { background: #14361b; color: #9ae6a0; }   /* NCNN — fast */
+.backend-badge.warn { background: #4a3210; color: #ffcf87; }   /* PyTorch — slow */

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -9,7 +9,8 @@ let state = {
     flipHorizontal: false,
     confidence: 0.25,
     isStreaming: false,
-    cameraMode: 'client' // 'client' | 'server'  — overridden by loadSettings()
+    cameraMode: 'client', // 'client' | 'server'  — overridden by loadSettings()
+    inferenceMode: 'live' // 'live' | 'snapshot' (Aim & Capture) — overridden by loadSettings()
 };
 
 
@@ -118,6 +119,15 @@ document.getElementById('cameraSourceSelect').addEventListener('change', (e) => 
     if (state.isStreaming) {
         stopCamera();
         alert("Camera source changed. Please click Start to resume.");
+    }
+});
+
+document.getElementById('inferenceModeSelect').addEventListener('change', (e) => {
+    state.inferenceMode = e.target.value;
+    saveSettings();
+    if (state.isStreaming) {
+        stopCamera();
+        alert("Inference mode changed. Please click Start to resume.");
     }
 });
 
@@ -355,6 +365,20 @@ function restartStreamInterval() {
 let _captureAndSend = () => {};
 
 async function startCamera() {
+    const snapshot = state.inferenceMode === 'snapshot';
+    _setCaptureBtn(snapshot);
+    _captureShown = false;
+
+    // Client camera + Aim & Capture: local preview only — no WebSocket, no per-frame
+    // inference. The single reading runs on "Capture & Analyze" via /predict?full.
+    if (snapshot && state.cameraMode === 'client') {
+        state.isStreaming = true;
+        document.getElementById('startBtn').disabled = true;
+        document.getElementById('stopBtn').disabled = false;
+        await _startClientPreview();
+        return;
+    }
+
     try {
         const [width, height] = state.resolution.split('x').map(Number);
 
@@ -371,7 +395,7 @@ async function startCamera() {
             if (state.cameraMode === 'client') {
                 startClientStream(width, height);
             } else {
-                startServerStream(width, height);
+                startServerStream(width, height, snapshot);  // snapshot => preview frames
             }
         };
 
@@ -403,6 +427,20 @@ async function startCamera() {
 
                 alert(`Camera error: ${data.error}`);
                 stopCamera();
+                return;
+            }
+
+            // Aim & Capture (server): raw preview frames carry no results. Show them,
+            // but don't overwrite a freshly captured reading (kept on screen briefly).
+            if (data.preview) {
+                if (!_captureShown) {
+                    document.getElementById('streamResult').src = 'data:image/jpeg;base64,' + data.image;
+                }
+                return;
+            }
+            // Aim & Capture (server): a full-res reading — freeze it on screen.
+            if (data.capture) {
+                _showCaptureResult(data);
                 return;
             }
 
@@ -469,9 +507,13 @@ async function startClientStream(width, height) {
     }
 }
 
-function startServerStream() {
+function startServerStream(width, height, preview = false) {
     if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ action: "start_server_stream", resolution: state.resolution }));
+        ws.send(JSON.stringify({
+            action: "start_server_stream",
+            resolution: state.resolution,
+            preview: !!preview,   // true = raw preview frames (Aim & Capture)
+        }));
     }
 }
 
@@ -532,8 +574,124 @@ function stopCamera() {
 
     state.isStreaming = false;
     _captureAndSend = () => {}; // reset so a stale interval can't fire
+
+    // Aim & Capture cleanup
+    _captureShown = false;
+    clearTimeout(_captureResumeTimer);
+    const _v = document.getElementById('videoElement');
+    if (_v) { _v.style.display = 'none'; _v.srcObject = null; }
+    _setCaptureBtn(false);
+    document.getElementById('streamResult').style.display = 'block';
+
     document.getElementById('startBtn').disabled = false;
     document.getElementById('stopBtn').disabled = true;
+}
+
+
+// ---------------------------------------------------------------------------
+// Aim & Capture (snapshot) mode helpers
+// ---------------------------------------------------------------------------
+
+let _captureShown = false;          // a captured reading is currently frozen on screen
+let _captureResumeTimer = null;
+
+function _setCaptureBtn(show) {
+    const btn = document.getElementById('captureAnalyzeBtn');
+    if (btn) btn.style.display = show ? '' : 'none';
+}
+
+// Client camera preview: show the local <video> live (no server round-trip, so smooth).
+async function _startClientPreview() {
+    try {
+        const [width, height] = state.resolution.split('x').map(Number);
+        const stream = await navigator.mediaDevices.getUserMedia({
+            video: { width, height, facingMode: { ideal: "environment" } }
+        });
+        videoStream = stream;
+        const video = document.getElementById('videoElement');
+        video.srcObject = stream;
+        await new Promise(r => video.onloadedmetadata = r);
+        video.play();
+        video.style.display = 'block';
+        document.getElementById('streamResult').style.display = 'none';
+    } catch (err) {
+        console.error("client preview error:", err);
+        alert("Could not access camera: " + err.message);
+        stopCamera();
+    }
+}
+
+// "Capture & Analyze" — one FULL-resolution reading (most accurate).
+async function captureAnalyze() {
+    const btn = document.getElementById('captureAnalyzeBtn');
+
+    // Server camera (Pi): ask the server to read the current frame at full res.
+    if (state.cameraMode === 'server') {
+        if (ws && ws.readyState === WebSocket.OPEN) {
+            if (btn) btn.disabled = true;
+            ws.send(JSON.stringify({ action: "capture_now" }));
+            setTimeout(() => { if (btn) btn.disabled = false; }, 2000);
+        }
+        return;
+    }
+
+    // Client camera: grab the current video frame → POST full-res to /predict.
+    const video = document.getElementById('videoElement');
+    if (!video || !video.videoWidth) return;
+    const w = video.videoWidth, h = video.videoHeight;
+    const canvas = document.getElementById('canvasElement');
+    const ctx = canvas.getContext('2d');
+    if (state.rotation === 90 || state.rotation === 270) { canvas.width = h; canvas.height = w; }
+    else { canvas.width = w; canvas.height = h; }
+    ctx.save();
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.translate(canvas.width / 2, canvas.height / 2);
+    ctx.rotate(state.rotation * Math.PI / 180);
+    if (state.flipHorizontal) ctx.scale(-1, 1);
+    ctx.drawImage(video, -w / 2, -h / 2, w, h);
+    ctx.restore();
+
+    if (btn) btn.disabled = true;
+    canvas.toBlob(async (blob) => {
+        try {
+            const fd = new FormData();
+            fd.append('file', blob, 'capture.jpg');
+            fd.append('conf', state.confidence);
+            fd.append('full', 'true');   // full-resolution reading
+            const res = await fetch('/predict', { method: 'POST', body: fd });
+            if (!res.ok) throw new Error('Server error: ' + res.status);
+            _showCaptureResult(await res.json());
+        } catch (e) {
+            alert("Capture failed: " + e.message);
+        } finally {
+            if (btn) btn.disabled = false;
+        }
+    }, 'image/jpeg', 0.92);
+}
+
+// Freeze a captured reading on screen, then auto-resume the live preview.
+function _showCaptureResult(data) {
+    _captureShown = true;
+    const img = document.getElementById('streamResult');
+    img.src = 'data:image/jpeg;base64,' + data.image;
+    img.style.display = 'block';
+    const video = document.getElementById('videoElement');
+    if (video) video.style.display = 'none';
+    updateTable(data.detections || [], 'streamTableBody');
+    updateMpnDisplay(data, 'streamMpnPattern', 'streamMpnValue', 'streamMpnCI', 'streamMpnRisk', 'streamMpnRiskItem');
+    clearTimeout(_captureResumeTimer);
+    _captureResumeTimer = setTimeout(_resumePreview, 5000);
+}
+
+function _resumePreview() {
+    _captureShown = false;
+    if (!state.isStreaming) return;
+    if (state.cameraMode === 'client') {
+        const video = document.getElementById('videoElement');
+        if (video) video.style.display = 'block';
+        document.getElementById('streamResult').style.display = 'none';
+    }
+    // Server mode resumes automatically — the next preview frame paints (flag cleared).
 }
 
 
@@ -1129,6 +1287,7 @@ function saveSettings() {
                     resolution:     state.resolution,
                     confidence:     state.confidence,
                     flipHorizontal: state.flipHorizontal,
+                    inferenceMode:  state.inferenceMode,
                 }),
             });
         } catch (e) {
@@ -1179,6 +1338,21 @@ async function loadSettings() {
             state.flipHorizontal = flip;
             const flipEl = document.getElementById('flipHorizontal');
             if (flipEl) flipEl.checked = flip;
+        }
+
+        // inferenceMode: prefer saved value, fall back to platform default
+        const im = saved.inferenceMode || data.default_inference_mode || 'live';
+        state.inferenceMode = im;
+        const imSel = document.getElementById('inferenceModeSelect');
+        if (imSel) imSel.value = im;
+
+        // inference backend badge (NCNN fast path vs PyTorch fallback)
+        const beEl = document.getElementById('modelBackend');
+        if (beEl) {
+            const be = data.model_backend || 'unknown';
+            if (be === 'ncnn')        { beEl.textContent = 'NCNN (fast)';      beEl.className = 'backend-badge ok'; }
+            else if (be === 'pytorch'){ beEl.textContent = 'PyTorch (slower)'; beEl.className = 'backend-badge warn'; }
+            else                      { beEl.textContent = be;                 beEl.className = 'backend-badge'; }
         }
 
         // network IP

--- a/templates/index.html
+++ b/templates/index.html
@@ -166,6 +166,11 @@
           <button class="btn danger" id="stopBtn" onclick="stopCamera()" disabled>
             <i class="fa-solid fa-stop"></i> Stop
           </button>
+          <!-- Shown only in Aim & Capture mode -->
+          <button class="btn primary" id="captureAnalyzeBtn" onclick="captureAnalyze()"
+                  style="display:none;">
+            <i class="fa-solid fa-camera"></i> Capture &amp; Analyze
+          </button>
         </div>
       </header>
 
@@ -406,6 +411,14 @@
             </select>
           </div>
           <div class="setting-item">
+            <label>Inference Mode</label>
+            <select id="inferenceModeSelect">
+              <option value="live">Live video (continuous — needs a fast device)</option>
+              <option value="snapshot">Aim &amp; Capture (smooth preview, snap one photo)</option>
+            </select>
+            <small>Aim &amp; Capture is smoother and more accurate on slow CPUs (VPS).</small>
+          </div>
+          <div class="setting-item">
             <label>Max FPS — <span id="fpsValue">5 FPS</span></label>
             <input type="range" id="fpsRange" min="1" max="30" value="5"
                    oninput="updateFpsDisplay(this.value)">
@@ -448,6 +461,11 @@
             <label>Confidence Threshold — <span id="confValue">0.25</span></label>
             <input type="range" id="confRange" min="0.1" max="1.0" step="0.05" value="0.25"
                    oninput="updateConfDisplay(this.value)">
+          </div>
+          <div class="setting-item">
+            <label>Inference Backend</label>
+            <span id="modelBackend" class="backend-badge">…</span>
+            <small>NCNN = fast CPU path. PyTorch = slower fallback (ncnn runtime missing).</small>
           </div>
         </div>
 


### PR DESCRIPTION
Speed (Problem 1): live per-frame inference is CPU-bound (slow on VPS/Pi).
- Add Settings "Inference Mode": Live (per-frame) vs Aim & Capture (smooth raw preview + one full-res reading). Persisted per device; default live on Pi, snapshot elsewhere (default_inference_mode).
- Client camera: local <video> preview, capture -> POST /predict?full=true.
- Server (Pi) camera: WS start_server_stream{preview:true} raw frames + capture_now full-res reading.
- inference.run_inference_with_count(scale_factor): 1.0 for accurate capture, 0.5 live.

NCNN visibility: expose inference.MODEL_BACKEND via /settings; Settings shows an "Inference Backend: NCNN (fast) / PyTorch (slower)" badge so each deployment makes the fast-path status obvious.

Docs: record Problem 1 (speed) + the two modes in STREAM_PERFORMANCE.md; Problem 2 (real-world domain shift / detection failure) + the controlled-rig vs diverse-data solutions in ACCURACY_IMPROVEMENT.md (Track 3 = user-owned environment/dataset).

Verified: app boots, /settings returns model_backend + default_inference_mode, page renders new controls, /predict?full=true works (P311/MPN 75).